### PR TITLE
Replaced getchildren with list(elem)

### DIFF
--- a/database_updater/npc_shop_parser.py
+++ b/database_updater/npc_shop_parser.py
@@ -15,9 +15,9 @@ def parse_npc_shop_data() -> typing.List[dict]:
 
     items = []
     # Parse xml structure
-    for npc in root.getchildren():
-        for section in npc.getchildren():
-            for item in section.getchildren():
+    for npc in list(root):
+        for section in list(npc):
+            for item in list(section):
                 items.append({
                     "npc_code": npc.attrib.get("NpcCode"),
                     "npc_class": int(npc.attrib.get("MerchantClass")),


### PR DESCRIPTION
Replaced deprecated getchildren() with list(elem).